### PR TITLE
Add JUnit tests for MathUtils.getPriceDiff

### DIFF
--- a/StockTechnicalAnalysis/src/test/java/com/lunstudio/stocktechnicalanalysis/util/MathUtilsTest.java
+++ b/StockTechnicalAnalysis/src/test/java/com/lunstudio/stocktechnicalanalysis/util/MathUtilsTest.java
@@ -1,0 +1,33 @@
+package com.lunstudio.stocktechnicalanalysis.util;
+
+import java.math.BigDecimal;
+
+import junit.framework.TestCase;
+
+public class MathUtilsTest extends TestCase {
+
+    public void testPositiveChange() {
+        BigDecimal result = MathUtils.getPriceDiff(new BigDecimal("100"), new BigDecimal("110"), 2);
+        assertEquals(new BigDecimal("10.00"), result);
+    }
+
+    public void testNegativeChange() {
+        BigDecimal result = MathUtils.getPriceDiff(new BigDecimal("100"), new BigDecimal("90"), 2);
+        assertEquals(new BigDecimal("-10.00"), result);
+    }
+
+    public void testInitialNull() {
+        BigDecimal result = MathUtils.getPriceDiff(null, new BigDecimal("50"), 2);
+        assertEquals(new BigDecimal("100.00"), result);
+    }
+
+    public void testFinalNull() {
+        BigDecimal result = MathUtils.getPriceDiff(new BigDecimal("50"), null, 2);
+        assertEquals(new BigDecimal("-100.00"), result);
+    }
+
+    public void testBothNull() {
+        BigDecimal result = MathUtils.getPriceDiff(null, null, 2);
+        assertNull(result);
+    }
+}


### PR DESCRIPTION
## Summary
- add a test suite for `MathUtils.getPriceDiff` covering positive, negative and null scenarios

## Testing
- `javac -d classes src/com/lunstudio/stocktechnicalanalysis/util/MathUtils.java`
- `javac -cp lib/junit-3.8.1.jar:classes -d classes src/test/java/com/lunstudio/stocktechnicalanalysis/util/MathUtilsTest.java`
- `java -cp lib/junit-3.8.1.jar:classes junit.textui.TestRunner com.lunstudio.stocktechnicalanalysis.util.MathUtilsTest`

------
https://chatgpt.com/codex/tasks/task_e_6880e194e5e48332a6f86f3a5c31f7ab